### PR TITLE
Import and use math.Abs() function

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -7,6 +7,7 @@ package ratelimit
 import (
 	gc "launchpad.net/gocheck"
 
+        "math"
 	"testing"
 	"time"
 )
@@ -261,7 +262,7 @@ func (rateLimitSuite) TestPanics(c *gc.C) {
 }
 
 func isCloseTo(x, y, tolerance float64) bool {
-	return abs(x-y)/y < tolerance
+	return math.Abs(x-y)/y < tolerance
 }
 
 func (rateLimitSuite) TestRate(c *gc.C) {


### PR DESCRIPTION
Hi there.  I am seeing an error running ratelimit_test.go due to the abs() function.  I'm sorry but I don't know much about Go, but using the math.Abs() function seems to fix the error.

Regards,

Tim.