### PR TITLE
Bucket: expose Available() and Capacity()

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -8,10 +8,10 @@
 package ratelimit
 
 import (
+	"math"
 	"strconv"
 	"sync"
 	"time"
-	"math"
 )
 
 // Bucket represents a token bucket that fills at a predetermined rate.
@@ -169,6 +169,28 @@ func (tb *Bucket) takeAvailable(now time.Time, count int64) int64 {
 	}
 	tb.avail -= count
 	return count
+}
+
+// Available returns the number of available tokens.
+// It will be negative when there are consumers waiting for tokens.
+// Note that this method is inherently racy - the returned count
+// may not be current but a moment later.
+func (tb *Bucket) Available() int64 {
+	return tb.available(time.Now())
+}
+
+// available is the internal version of available - it takes the current time as
+// an argument to enable easy testing.
+func (tb *Bucket) available(now time.Time) int64 {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.adjust(now)
+	return tb.avail
+}
+
+// Capacity returns the capacity that the bucket was created with.
+func (tb *Bucket) Capacity() int64 {
+	return tb.capacity
 }
 
 // Rate returns the fill rate of the bucket, in tokens per second.

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -5,10 +5,11 @@
 package ratelimit
 
 import (
-	gc "launchpad.net/gocheck"
-
+	"math"
 	"testing"
 	"time"
+
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *testing.T) {
@@ -261,7 +262,7 @@ func (rateLimitSuite) TestPanics(c *gc.C) {
 }
 
 func isCloseTo(x, y, tolerance float64) bool {
-	return abs(x-y)/y < tolerance
+	return math.Abs(x-y)/y < tolerance
 }
 
 func (rateLimitSuite) TestRate(c *gc.C) {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -126,6 +126,49 @@ var takeTests = []struct {
 	}},
 }}
 
+var availTests = []struct {
+	about        string
+	capacity     int64
+	fillInterval time.Duration
+	take         int64
+	sleep        time.Duration
+
+	expectCountAfterTake  int64
+	expectCountAfterSleep int64
+}{{
+	about:                 "should fill tokens after interval",
+	capacity:              5,
+	fillInterval:          time.Second,
+	take:                  5,
+	sleep:                 time.Second,
+	expectCountAfterTake:  0,
+	expectCountAfterSleep: 1,
+}, {
+	about:                 "should fill tokens plus existing count",
+	capacity:              2,
+	fillInterval:          time.Second,
+	take:                  1,
+	sleep:                 time.Second,
+	expectCountAfterTake:  1,
+	expectCountAfterSleep: 2,
+}, {
+	about:                 "shouldn't fill before interval",
+	capacity:              2,
+	fillInterval:          2 * time.Second,
+	take:                  1,
+	sleep:                 time.Second,
+	expectCountAfterTake:  1,
+	expectCountAfterSleep: 1,
+}, {
+	about:                 "should fill only once after 1*interval before 2*interval",
+	capacity:              2,
+	fillInterval:          2 * time.Second,
+	take:                  1,
+	sleep:                 3 * time.Second,
+	expectCountAfterTake:  1,
+	expectCountAfterSleep: 2,
+}}
+
 func (rateLimitSuite) TestTake(c *gc.C) {
 	for i, test := range takeTests {
 		tb := NewBucket(test.fillInterval, test.capacity)
@@ -319,6 +362,23 @@ func (rateLimitSuite) TestNewWithRate(c *gc.C) {
 		checkRate(c, rate/3)
 		checkRate(c, rate*1.3)
 	}
+}
+
+func TestAvailable(t *testing.T) {
+	for i, tt := range availTests {
+		tb := NewBucket(tt.fillInterval, tt.capacity)
+		if c := tb.takeAvailable(tb.startTime, tt.take); c != tt.take {
+			t.Fatalf("#%d: %s, take = %d, want = %d", i, tt.about, c, tt.take)
+		}
+		if c := tb.available(tb.startTime); c != tt.expectCountAfterTake {
+			t.Fatalf("#%d: %s, after take, available = %d, want = %d", i, tt.about, c, tt.expectCountAfterTake)
+		}
+		if c := tb.available(tb.startTime.Add(tt.sleep)); c != tt.expectCountAfterSleep {
+			t.Fatalf("#%d: %s, after some time it should fill in new tokens, available = %d, want = %d",
+				i, tt.about, c, tt.expectCountAfterSleep)
+		}
+	}
+
 }
 
 func BenchmarkWait(b *testing.B) {


### PR DESCRIPTION
Hi,

The current token bucket implementation is great. Nonetheless we need some underlying data to implement more powerful functionalities.

For example, if we want to implement a function `CanAccept` which only checks available tokens without taking it; implement a function that exports rate limiter's metrics to better understand current flow and bottleneck on our services. Both functions will benefit if we can get the underlying data like `avail` and `capacity`, including the already public `Rate()`.

Let me know if there are questions. Highly appreciate it if anyone can help review this issue. Thanks!