### PR TITLE
Removed defered mutex unlocks in favor of explicit calls

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -387,3 +387,12 @@ func BenchmarkWait(b *testing.B) {
 		tb.Wait(1)
 	}
 }
+
+func BenchmarkWaitParallel(b *testing.B) {
+	tb := NewBucket(1, 16*1024)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tb.Wait(1)
+		}
+	})
+}


### PR DESCRIPTION
I've been playing around with a few potential changes to this package for potential speed improvements and found that the act of defering the mutex unlocks is a significant slow down to this package. Once these were removed and appropriate adjustments made in the code it appears to have resulted in an 3 times increase in parallel calls to Wait().

Before:

```
go test -bench . -benchmem -cpu 1,2,4,8

PASS
BenchmarkWait           10000000               152 ns/op               0 B/op          0 allocs/op
BenchmarkWait-2         10000000               155 ns/op               0 B/op          0 allocs/op
BenchmarkWait-4         10000000               153 ns/op               0 B/op          0 allocs/op
BenchmarkWait-8         10000000               152 ns/op               0 B/op          0 allocs/op
BenchmarkWaitParallel   10000000               160 ns/op               0 B/op          0 allocs/op
BenchmarkWaitParallel-2 10000000               164 ns/op               0 B/op          0 allocs/op
BenchmarkWaitParallel-4 10000000               178 ns/op               0 B/op          0 allocs/op
BenchmarkWaitParallel-8 10000000               185 ns/op               0 B/op          0 allocs/op
```

After:

```
go test -bench . -benchmem -cpu 1,2,4,8

PASS
BenchmarkWait           30000000                56.1 ns/op             0 B/op          0 allocs/op
BenchmarkWait-2         30000000                56.0 ns/op             0 B/op          0 allocs/op
BenchmarkWait-4         30000000                55.8 ns/op             0 B/op          0 allocs/op
BenchmarkWait-8         30000000                55.8 ns/op             0 B/op          0 allocs/op
BenchmarkWaitParallel   30000000                56.9 ns/op             0 B/op          0 allocs/op
BenchmarkWaitParallel-2 30000000                59.3 ns/op             0 B/op          0 allocs/op
BenchmarkWaitParallel-4 20000000                68.1 ns/op             0 B/op          0 allocs/op
BenchmarkWaitParallel-8 20000000                70.8 ns/op             0 B/op          0 allocs/op
```
