### PR TITLE
allocate less in NewBucketWithRateAndClock

### DIFF
--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -387,3 +387,9 @@ func BenchmarkWait(b *testing.B) {
 		tb.Wait(1)
 	}
 }
+
+func BenchmarkNewBucket(b *testing.B) {
+	for i := b.N - 1; i >= 0; i-- {
+		NewBucketWithRate(4e18, 1<<62)
+	}
+}


### PR DESCRIPTION
As suggested by @helinbo2015 in issue #19.

    benchmark                old ns/op     new ns/op     delta
    BenchmarkNewBucket-4     2965          892           -69.92%