### PR TITLE
Add ModifyCapacity method

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -265,6 +265,13 @@ func (tb *Bucket) Capacity() int64 {
 	return tb.capacity
 }
 
+// ModifyCapacity modify current bucket capacity.
+func (tb *Bucket) ModifyCapacity(newCapacity int64) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.capacity = newCapacity
+}
+
 // Rate returns the fill rate of the bucket, in tokens per second.
 func (tb *Bucket) Rate() float64 {
 	return 1e9 * float64(tb.quantum) / float64(tb.fillInterval)


### PR DESCRIPTION
This method is used to dynamically transform capacity.

@manadart @rogpeppe  If capacity needs to be changed, a new bucket must be created. This method allows you to safely change capacity without creating a new bucket.